### PR TITLE
Update pdnsd.spec.in - removed --parents option

### DIFF
--- a/pdnsd.spec.in
+++ b/pdnsd.spec.in
@@ -108,7 +108,7 @@ make DESTDIR="$RPM_BUILD_ROOT" install
 cp -f file-list.base file-list
 find doc contrib -not -type d -not -iname '*makefile' -not -name '*.am' \
                  -not -name '*.in' -not -path 'doc/*.pl' |
-sed -e 's/^/%doc --parents /'  >> file-list
+sed -e 's/^/%doc /'  >> file-list
 CURDIR=$PWD; cd "$RPM_BUILD_ROOT"
 find . -not -type d '(' -not -name 'pdnsd.conf*' -or -name 'pdnsd.conf.[1-9]*' ')' \
        -not -path '.%{_docdir}/*' -not -path './var/*' |


### PR DESCRIPTION
rpmbuild fails to build due to --parents option provided to %doc entries in pdnsd.spec.in on Redhat 7.1.  

Removed --parents option.  HTML doc files stored in root of doc directory in RPM, but rpmbuild can now build the package.

Error output:

```
+ cp -pr --parents /home/clarkd/rpmbuild/BUILDROOT/pdnsd-1.2.9a-par.x86_64/usr/share/doc/pdnsd-1.2.9a
cp: missing destination file operand after '/home/clarkd/rpmbuild/BUILDROOT/pdnsd-1.2.9a-par.x86_64/usr/share/doc/pdnsd-1.2.9a'
Try 'cp --help' for more information.
error: Bad exit status from /var/tmp/rpm-tmp.4rg4Xa (%doc)
```
